### PR TITLE
Fixed Firebase login not working with Networking enabled

### DIFF
--- a/StanwoodDebugger/Controller/LogManagers/DebuggerNetworking.swift
+++ b/StanwoodDebugger/Controller/LogManagers/DebuggerNetworking.swift
@@ -37,7 +37,7 @@ extension NSMutableURLRequest {
     
     @objc func httpHack(body: NSData?) {
         defer {
-//            httpHack(body: body)
+            httpHack(body: body)
         }
         
         let key = "\(hashValue)"


### PR DESCRIPTION
I've tested the email & Facebook login, and a Stripe checkout in Lenny, that works fine too.
I couldn't find any more 3rd party libs that's doing networking in WUN or LEN. Our API calls have been working well before.