### PR TITLE
Shake to enable/disable

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - StanwoodCore (1.4.1)
-  - StanwoodDebugger (1.0.1):
+  - StanwoodDebugger (1.0.2):
     - StanwoodCore (~> 1.4.1)
     - Toast-Swift (~> 4.0.1)
   - Toast-Swift (4.0.1)
@@ -20,9 +20,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   StanwoodCore: 9f58032a58b16e9b5ebbb2906b7888d87c098642
-  StanwoodDebugger: c73f2adf4cff7c1c148242209ca7fdd088137255
+  StanwoodDebugger: 89fdd39feeee00a65d1862d1cae48b7749e80b2c
   Toast-Swift: e42a638589a2f95036b4bb7626cfbdde7daf0393
 
 PODFILE CHECKSUM: d9da7538a1f96fc96c8e13d2f601e09605b903af
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/Example/StanwoodDebugger.xcodeproj/project.pbxproj
+++ b/Example/StanwoodDebugger.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-StanwoodDebugger_Example/Pods-StanwoodDebugger_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-StanwoodDebugger_Example/Pods-StanwoodDebugger_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/StanwoodCore/StanwoodCore.framework",
 				"${BUILT_PRODUCTS_DIR}/StanwoodDebugger/StanwoodDebugger.framework",
 				"${BUILT_PRODUCTS_DIR}/Toast-Swift/Toast_Swift.framework",
@@ -401,7 +401,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-StanwoodDebugger_Example/Pods-StanwoodDebugger_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-StanwoodDebugger_Example/Pods-StanwoodDebugger_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C482FB05DEBDF2AE5DA44852 /* [CP] Check Pods Manifest.lock */ = {

--- a/Example/StanwoodDebugger.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/StanwoodDebugger.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ debugger.enabledServices: [Service] = [.logs, .errors] /// The services you woul
 debugger.tintColor = .red /// Change the tint color
 debugger.errorCodesExceptions = [4097] /// Add error code exceptions
 debugger.isEnabled = true
+debugger.isShakeEnabled = true // Defaults to `true`. When this is `true`, shaking the device will enable/disable the Debugger
 ```
 
 ## Adding logs

--- a/StanwoodDebugger.podspec
+++ b/StanwoodDebugger.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'StanwoodDebugger'
-  s.version          = '1.0.1'
+  s.version          = '1.0.2'
   s.summary          = 'Stanwood debugger provide live view debugging'
   s.description      = <<-DESC
     Live debugger for:

--- a/StanwoodDebugger/Extensions/Notification+Name+Extension.swift
+++ b/StanwoodDebugger/Extensions/Notification+Name+Extension.swift
@@ -75,4 +75,7 @@ extension Notification.Name {
     static var DebuggerDidAddDebuggerItem: Notification.Name {
         return NSNotification.Name(rawValue: "io.stanwood.debugger.didAddDebuggerItem")
     }
+    
+    // MARK: - Shake
+    static let Shake = Notification.Name("io.stanwood.debugger.shake")
 }

--- a/StanwoodDebugger/Extensions/UIView+Extension.swift
+++ b/StanwoodDebugger/Extensions/UIView+Extension.swift
@@ -106,4 +106,50 @@ extension UIView {
         
         return shadowLayer
     }
+    
+    // Shake
+    enum SimpleAnimationEdge {
+        case none
+        case top
+        case bottom
+        case left
+        case right
+    }
+    
+    @discardableResult func shake(toward edge: SimpleAnimationEdge = .none,
+                                  amount: CGFloat = 0.15,
+                                  duration: TimeInterval = 0.6,
+                                  delay: TimeInterval = 0,
+                                  completion: ((Bool) -> Void)? = nil) -> UIView {
+        let steps = 8
+        let timeStep = 1.0 / Double(steps)
+        var dx: CGFloat, dy: CGFloat
+        if edge == .left || edge == .right {
+            dx = (edge == .left ? -1 : 1) * self.bounds.size.width * amount;
+            dy = 0
+        } else {
+            dx = 0
+            dy = (edge == .top ? -1 : 1) * self.bounds.size.height * amount;
+        }
+        UIView.animateKeyframes(
+            withDuration: duration, delay: delay, options: .calculationModeCubic, animations: {
+                var start = 0.0
+                for i in 0..<(steps - 1) {
+                    UIView.addKeyframe(withRelativeStartTime: start, relativeDuration: timeStep) {
+                        self.transform = CGAffineTransform(translationX: dx, y: dy)
+                    }
+                    if (edge == .none && i % 2 == 0) {
+                        swap(&dx, &dy)  // Change direction
+                        dy *= -1
+                    }
+                    dx *= -0.85
+                    dy *= -0.85
+                    start += timeStep
+                }
+                UIView.addKeyframe(withRelativeStartTime: start, relativeDuration: timeStep) {
+                    self.transform = .identity
+                }
+        }, completion: completion)
+        return self
+    }
 }

--- a/StanwoodDebugger/Extensions/UIViewController+TopMost.swift
+++ b/StanwoodDebugger/Extensions/UIViewController+TopMost.swift
@@ -8,34 +8,33 @@
 import Foundation
 
 extension UIViewController {
-    @objc func topMostViewController() -> UIViewController {
-        // Handling Modal views
-        if let presentedViewController = self.presentedViewController {
-            return presentedViewController.topMostViewController()
-        }
-            
-            // Handling UIViewControllers added as subviews to some other views.
-        else {
+    @objc func topMostViewController() -> UIViewController? {
+        
+        // Handling UIViewControllers added as subviews to some other views.
+        guard let presented = self.presentedViewController else {
             for view in self.view.subviews {
-                if let subViewController = view.next {
-                    if let viewController = subViewController as? UIViewController {
-                        return viewController.topMostViewController()
-                    }
+                if let subViewController = view.next,
+                    let viewController = subViewController as? UIViewController {
+                    return viewController.topMostViewController()
                 }
             }
             return self
         }
+        
+        
+        // Handling Modal views
+        return presented.topMostViewController()
     }
 }
 
 extension UITabBarController {
-    override func topMostViewController() -> UIViewController {
-        return self.selectedViewController!.topMostViewController()
+    override func topMostViewController() -> UIViewController? {
+        return self.selectedViewController?.topMostViewController()
     }
 }
 
 extension UINavigationController {
-    override func topMostViewController() -> UIViewController {
-        return self.visibleViewController!.topMostViewController()
+    override func topMostViewController() -> UIViewController? {
+        return self.visibleViewController?.topMostViewController()
     }
 }

--- a/StanwoodDebugger/Extensions/UIViewController+TopMost.swift
+++ b/StanwoodDebugger/Extensions/UIViewController+TopMost.swift
@@ -1,0 +1,41 @@
+//
+//  UIViewController+TopMost.swift
+//  StanwoodDebugger
+//
+//  Created by Zolo on 2019. 05. 13..
+//
+
+import Foundation
+
+extension UIViewController {
+    @objc func topMostViewController() -> UIViewController {
+        // Handling Modal views
+        if let presentedViewController = self.presentedViewController {
+            return presentedViewController.topMostViewController()
+        }
+            
+            // Handling UIViewControllers added as subviews to some other views.
+        else {
+            for view in self.view.subviews {
+                if let subViewController = view.next {
+                    if let viewController = subViewController as? UIViewController {
+                        return viewController.topMostViewController()
+                    }
+                }
+            }
+            return self
+        }
+    }
+}
+
+extension UITabBarController {
+    override func topMostViewController() -> UIViewController {
+        return self.selectedViewController!.topMostViewController()
+    }
+}
+
+extension UINavigationController {
+    override func topMostViewController() -> UIViewController {
+        return self.visibleViewController!.topMostViewController()
+    }
+}

--- a/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
+++ b/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
@@ -9,9 +9,11 @@ import Foundation
 
 extension UserDefaults {
     struct Keys {
-        static let hintShown = "showHint"
+        static let isHintShown = "isHintShown"
     }
     
-    static var hintShown: Bool { return UserDefaults.standard.bool(forKey: UserDefaults.Keys.hintShown) }
-    static func set(hintShown: Bool) { UserDefaults.standard.set(hintShown, forKey: UserDefaults.Keys.hintShown) }
+    static var isHintShown: Bool {
+        get { return standard.bool(forKey: #function) }
+        set { standard.set(newValue, forKey: #function) }
+    }
 }

--- a/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
+++ b/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
@@ -1,0 +1,17 @@
+//
+//  UserDefaults+Keys.swift
+//  Pods-StanwoodDebugger_Example
+//
+//  Created by Zolo on 2019. 05. 13..
+//
+
+import Foundation
+
+extension UserDefaults {
+    struct Keys {
+        static let hintShown = "showHint"
+    }
+    
+    static var hintShown: Bool { return UserDefaults.standard.bool(forKey: UserDefaults.Keys.hintShown) }
+    static func set(hintShown: Bool) { UserDefaults.standard.set(hintShown, forKey: UserDefaults.Keys.hintShown) }
+}

--- a/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
+++ b/StanwoodDebugger/Extensions/UserDefaults+Keys.swift
@@ -8,10 +8,6 @@
 import Foundation
 
 extension UserDefaults {
-    struct Keys {
-        static let isHintShown = "isHintShown"
-    }
-    
     static var isHintShown: Bool {
         get { return standard.bool(forKey: #function) }
         set { standard.set(newValue, forKey: #function) }

--- a/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
+++ b/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
@@ -25,6 +25,8 @@
 //
 
 import Foundation
+import StanwoodCore
+import Toast_Swift
 
 protocol DebuggerViewable: class {
     var debuggerScallableView: DebuggerScallableView? { get set }
@@ -42,6 +44,21 @@ class DebuggerViewController: UIViewController, DebuggerViewable {
         debuggerButton = DebuggerUIButton(debugger: presenter.debugger)
         debuggerButton.addTarget(self, action: #selector(didTapDebuggerButton(target:)), for: .touchUpInside)
         view.addSubview(debuggerButton)
+
+        showShakeHint()
+    }
+    
+    private func showShakeHint() {
+        if !UserDefaults.hintShown {
+            UserDefaults.set(hintShown: true)
+            debuggerButton.shake(toward: .right, amount: 0.18, duration: 1.5, delay: 0.5)
+            DispatchQueue.main.asyncAfter(deadline: .now()+0.8) {
+                var style = ToastStyle(); style.backgroundColor = StanwoodDebugger.Style.tintColor
+                let toast = try! self.view.toastViewForMessage("Shake to disable the Debugger", title: nil, image: nil, style: style)
+                let screen = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController()
+                screen?.view.showToast(toast)
+            }
+        }
     }
 
     @objc func didTapDebuggerButton(target: DebuggerUIButton) {

--- a/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
+++ b/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
@@ -49,14 +49,19 @@ class DebuggerViewController: UIViewController, DebuggerViewable {
     }
     
     private func showShakeHint() {
-        if !UserDefaults.hintShown {
-            UserDefaults.set(hintShown: true)
+        if !UserDefaults.isHintShown {
+            UserDefaults.isHintShown = true
+            
+            // Shake
             debuggerButton.shake(toward: .right, amount: 0.18, duration: 1.5, delay: 0.5)
-            DispatchQueue.main.asyncAfter(deadline: .now()+0.8) {
+            
+            // Toast
+            main {
                 var style = ToastStyle(); style.backgroundColor = StanwoodDebugger.Style.tintColor
-                let toast = try! self.view.toastViewForMessage("Shake to disable the Debugger", title: nil, image: nil, style: style)
+                let toast = try? self.view.toastViewForMessage("Shake to disable the Debugger", title: nil, image: nil, style: style)
                 let screen = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController()
-                screen?.view.showToast(toast)
+                guard let toastDone = toast else { return }
+                screen?.view.showToast(toastDone)
             }
         }
     }


### PR DESCRIPTION
I ended up swizzling UIApplication to intercept shake events, because extending the ViewController didn't work out.  

For one, I had no luck getting `motionEnded(_:with:)` called on the Debugger's VC. I did manage to get it called on the app's VC, but AFAIK there's some responder chain magic that decides which object gets called with `motionEnded` and which isn't.

Also, detecting shakes on the ViewController seems to require it being the first responder which will not be the case as soon as peeps start editing some text field.

Swizzling UIApplication works great, though.