### PR TITLE
Fixes some issues with the expanded UI in regards to shaking

### DIFF
--- a/StanwoodDebugger/Controller/Debugger.swift
+++ b/StanwoodDebugger/Controller/Debugger.swift
@@ -108,6 +108,7 @@ public class StanwoodDebugger: Debugging {
         actions.coordinator = coordinator
         
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didDismissFullscreen), name: NSNotification.Name.DebuggerDidDismissFullscreen, object: nil)
         
         configureStyle()
         observeCrashes()
@@ -162,20 +163,25 @@ public class StanwoodDebugger: Debugging {
             if debuggerViewController == nil {
                 debuggerViewController = DebuggerWireframe.makeViewController()
                 DebuggerWireframe.prepare(debuggerViewController, with: actions, paramaters, self)
+                window.rootViewController = debuggerViewController
+                window.makeKeyAndVisible()
+                window.delegate = self
             }
-            window.rootViewController = debuggerViewController
-            window.makeKeyAndVisible()
-            window.delegate = self
-
+            window.isHidden = false
+            window.isUserInteractionEnabled = true
+            
             if DebuggerCrash.didReceiveCrash {
                 DebuggerCrash.didReceiveCrash = false
                 NotificationCenter.default.post(name: NSNotification.Name.DebuggerDidAddDebuggerItem, object: [AddedItem(type: .crashes(item: nil), count: 1)])
             }
         case false:
-            window.rootViewController = nil
-            window.resignKey()
-            window.removeFromSuperview()
+            window.isHidden = true
+            window.isUserInteractionEnabled = false
        }
+    }
+    
+    @objc private func didDismissFullscreen() {
+        isDisplayed = false
     }
 }
 

--- a/StanwoodDebugger/Extensions/Notification+Name+Extension.swift
+++ b/StanwoodDebugger/Extensions/Notification+Name+Extension.swift
@@ -78,4 +78,7 @@ extension Notification.Name {
     
     // MARK: - Shake
     static let Shake = Notification.Name("io.stanwood.debugger.shake")
+    
+    // MARK: - Dismissal
+    static let DebuggerDidDismissFullscreen = Notification.Name("io.stanwood.debugger.didDismissFullscreen")
 }

--- a/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
+++ b/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
@@ -58,7 +58,7 @@ class DebuggerViewController: UIViewController, DebuggerViewable {
             // Toast
             main {
                 var style = ToastStyle(); style.backgroundColor = StanwoodDebugger.Style.tintColor
-                let toast = try? self.view.toastViewForMessage("Shake to disable the Debugger", title: nil, image: nil, style: style)
+                let toast = try? self.view.toastViewForMessage("Shake me to dismiss the Debugger", title: nil, image: nil, style: style)
                 let screen = UIApplication.shared.keyWindow?.rootViewController?.topMostViewController()
                 guard let toastDone = toast else { return }
                 screen?.view.showToast(toastDone)

--- a/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
+++ b/StanwoodDebugger/Modules/Bubble/DebuggerViewController.swift
@@ -82,7 +82,6 @@ class DebuggerViewController: UIViewController, DebuggerViewable {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        presenter.debugger.isDisplayed = false
         debuggerButton.preparePulse()
         debuggerButton.isPulseEnabled = true
     }

--- a/StanwoodDebugger/Modules/List/ListViewController.swift
+++ b/StanwoodDebugger/Modules/List/ListViewController.swift
@@ -80,6 +80,7 @@ class ListViewController: UIViewController, ListViewable {
     }
     
     @objc func dismissDebuggerView() {
+        NotificationCenter.default.post(name: NSNotification.Name.DebuggerDidDismissFullscreen, object: nil)
         tabBarController?.dismiss(animated: true, completion: nil)
     }
     


### PR DESCRIPTION
- Fixes an issue where the scalable view would stop responding to touches after a shake cycle
- Fixes an issue where the expanded view controller wouldn't hide after a shake
- Makes it so that the debugger UI is restored as it were after a shake cycle

_shake cycle = shaking to disable then enable_

---

When I was recording the video yesterday I noticed the scalable view was not responding to touches after a shake cycle and investigating that bug led me down a rabbit whole with all kinds of problems with the scalable view and the expanded view controller in regards to shaking. Most notably the scalable view would stop recognizing touches because of an incorrect `isDisplayed` state and the expanded VC wouldn't even disappear upon `isEnabled = true` (even though the window was being removed from the superview ¯\_(ツ)_/¯.

I contemplated just dismissing the expanded VC upon shaking, but that felt lazy and I thought some peeps could benefit from a behaviour where reenabling the debugger would bring back the UI as it was. That way we can have the Debugger in full screen mode constantly and just shake the device to see the debug area (and shake again to hide) without having to tap buttons.

---

Regarding the implementation of the fix, I removed setting `isDisplayed = false` (it was weird to have that there in the first place, but I know why it was there) from `viewWillAppear` and made sure it's called even after dismissing the expanded VC.

As far as I understand this is how presenting the expanded VC (ListViewController) works:
`Debugger` -> | -> `coordinator` -> `listwireframe` -> `listviewcontroller`

The problem is that `listviewcontroller` needs to call `isDisplayed = false` when it gets dismissed, but that's a property on `Debugger`. I thought about injecting the debugger into the `coordinator` then into the `wireframe` then into the `viewcontroller`, but that would have been a lot of noise and I don't like that. Another other option was to have a delegate on listviewcontroller, but then that would have had to travel up the chain until the `debugger` too, so that would have also been a lot of noise code.

In the end I just used a notification and added a handler in Debugger, but using notifications feel like getting around the architecture.

**Question**: Does the stanwood arch have a solution to something like this that I'm missing?